### PR TITLE
delegate jobtap plugin: delegate without exceptions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,25 +1,43 @@
 BasedOnStyle : google
 SpaceBeforeParens : Always
 IndentWidth : 4
-BreakBeforeBraces : Linux
+BreakBeforeBraces : Custom
+BraceWrapping :
+  BeforeElse : false
+  AfterFunction : true
 UseTab: Never
 AllowShortIfStatementsOnASingleLine : false
 ConstructorInitializerAllOnOneLineOrOnePerLine : true
 AllowShortFunctionsOnASingleLine : false
 AllowShortLoopsOnASingleLine : false
 BinPackParameters : false
+BinPackArguments : false
 AllowAllParametersOfDeclarationOnNextLine : false
 AlignTrailingComments : true
-ColumnLimit : 88
+ColumnLimit : 100
 
 # do not put all arguments on one line unless it's the same line as the call
 PenaltyBreakBeforeFirstCallParameter : 10000000
 PenaltyReturnTypeOnItsOwnLine : 65000
 PenaltyBreakString : 10
 
-# These improve formatting results but require clang 3.6/7 or higher
+# treat foreach macros as for loops
+ForEachMacros :
+  - json_array_foreach
+  - json_object_foreach
+
+SortIncludes : false
 BreakBeforeBinaryOperators : NonAssignment
-AlignAfterOpenBracket: true
-BinPackArguments : false
+AlignAfterOpenBracket: Align
 AlignOperands : true
 BreakBeforeTernaryOperators : true
+SpaceBeforeSquareBrackets: false
+IndentPPDirectives: None
+NamespaceIndentation: None
+SpaceAfterTemplateKeyword: false
+DerivePointerAlignment: false
+PointerAlignment: Right
+
+#
+# vi:tabstop=4 shiftwidth=4 expandtab ft=yaml
+#

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -144,12 +144,7 @@ static void wait_callback (flux_future_t *f, void *arg)
             return;
         }
     }
-    flux_jobtap_raise_exception (p,
-                                 *id,
-                                 "DelegationFailure",
-                                 0,
-                                 "errstr %s",
-                                 errstr);
+    flux_jobtap_raise_exception (p, *id, "DelegationFailure", 0, "errstr %s", errstr);
     flux_future_destroy (f);
 }
 
@@ -175,8 +170,7 @@ static void event_callback (flux_future_t *f, void *arg)
         return;
     }
     id = (flux_jobid_t)*json_id;
-    if (flux_job_event_watch_get (f, &event) != 0
-        || !(o = eventlog_entry_decode (event))
+    if (flux_job_event_watch_get (f, &event) != 0 || !(o = eventlog_entry_decode (event))
         || eventlog_entry_parse (o, &timestamp, &name, &context) < 0) {
         json_decref (o);
         flux_log_error (h, "Error decoding/parsing eventlog entry for %" PRIu64, id);
@@ -186,12 +180,7 @@ static void event_callback (flux_future_t *f, void *arg)
         /*  'start' event with no cray_port_distribution event.
          *  assume cray-pals jobtap plugin is not loaded.
          */
-        if (flux_jobtap_event_post_pack (p,
-                                         id,
-                                         "delegate::start",
-                                         "{s:f}",
-                                         "timestamp",
-                                         timestamp)
+        if (flux_jobtap_event_post_pack (p, id, "delegate::start", "{s:f}", "timestamp", timestamp)
             < 0) {
             flux_log_error (h, "could not post delegate::start event for %" PRIu64, id);
         }
@@ -226,13 +215,11 @@ static void submit_callback (flux_future_t *f, void *arg)
         flux_future_destroy (f);
         return;
     }
-    if (!(delegated_h = flux_future_get_flux (f))
-        || flux_job_submit_get_id (f, &delegated_id) < 0
+    if (!(delegated_h = flux_future_get_flux (f)) || flux_job_submit_get_id (f, &delegated_id) < 0
         || !(wait_future = flux_job_wait (delegated_h, delegated_id))
         || flux_future_aux_set (wait_future, "flux::jobid", orig_id, NULL) < 0
         || flux_future_then (wait_future, -1, wait_callback, p) < 0
-        || !(event_future =
-                 flux_job_event_watch (delegated_h, delegated_id, "eventlog", 0))
+        || !(event_future = flux_job_event_watch (delegated_h, delegated_id, "eventlog", 0))
         || flux_future_aux_set (event_future, "flux::jobid", orig_id, NULL) < 0
         || flux_future_aux_set (event_future, "flux::handle", h, NULL) < 0
         || flux_future_then (event_future, -1, event_callback, p) < 0
@@ -299,10 +286,7 @@ static char *remove_dependency_and_encode (json_t *jobspec)
 /*
  * Handle job.dependency.delegate requests
  */
-static int depend_cb (flux_plugin_t *p,
-                      const char *topic,
-                      flux_plugin_arg_t *args,
-                      void *arg)
+static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
 {
     flux_t *h = flux_jobtap_get_flux (p);
     json_int_t *id;
@@ -355,8 +339,7 @@ static int depend_cb (flux_plugin_t *p,
     // submit the job to the specified instance and attach a callback for fetching the
     // ID
     if (!(encoded_jobspec = remove_dependency_and_encode (jobspec))
-        || !(jobid_future =
-                 flux_job_submit (delegated, encoded_jobspec, 16, FLUX_JOB_WAITABLE))
+        || !(jobid_future = flux_job_submit (delegated, encoded_jobspec, 16, FLUX_JOB_WAITABLE))
         || flux_future_then (jobid_future, -1, submit_callback, p) < 0
         || flux_future_aux_set (jobid_future, "flux::jobid", id, NULL) < 0) {
         flux_log_error (h,

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -353,6 +353,15 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
     }
     // submit the job to the specified instance and attach a callback for fetching the
     // ID
+    if (flux_jobtap_job_set_flag (p, FLUX_JOBTAP_CURRENT_JOB, "alloc-bypass") < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc",
+                                     0,
+                                     "Failed to set alloc-bypass: %s",
+                                     strerror (errno));
+        return -1;
+    }
     if (!(encoded_jobspec = remove_dependency_and_encode (jobspec))
         || !(jobid_future = flux_job_submit (delegated, encoded_jobspec, 16, FLUX_JOB_WAITABLE))
         || flux_future_then (jobid_future, -1, submit_callback, p) < 0

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -16,11 +16,27 @@
 #include "config.h"
 #endif
 
-#include <flux/core.h>
-#include <flux/jobtap.h>
 #include <inttypes.h>
 #include <jansson.h>
 #include <stdint.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+/*  Convenience function to convert a flux_jobid_t to F58 encoding
+ *  If the encode fails (unlikely), then the decimal encoding is returned.
+ */
+static inline const char *idf58 (flux_jobid_t id)
+{
+    static __thread char buf[21];
+    if (flux_job_id_encode (id, "f58", buf, sizeof (buf)) < 0) {
+        /* 64bit integer is guaranteed to fit in 21 bytes
+         * floor(log(2^64-1)/log(1)) + 1 = 20
+         */
+        (void)sprintf (buf, "%ju", (uintmax_t)id);
+    }
+    return buf;
+}
 
 bool eventlog_entry_validate (json_t *entry)
 {
@@ -173,7 +189,7 @@ static void event_callback (flux_future_t *f, void *arg)
     if (flux_job_event_watch_get (f, &event) != 0 || !(o = eventlog_entry_decode (event))
         || eventlog_entry_parse (o, &timestamp, &name, &context) < 0) {
         json_decref (o);
-        flux_log_error (h, "Error decoding/parsing eventlog entry for %" PRIu64, id);
+        flux_log_error (h, "Error decoding/parsing eventlog entry for %s", idf58 (id));
         return;
     }
     if (!strcmp (name, "start")) {
@@ -182,7 +198,7 @@ static void event_callback (flux_future_t *f, void *arg)
          */
         if (flux_jobtap_event_post_pack (p, id, "delegate::start", "{s:f}", "timestamp", timestamp)
             < 0) {
-            flux_log_error (h, "could not post delegate::start event for %" PRIu64, id);
+            flux_log_error (h, "could not post delegate::start event for %s", idf58 (id));
         }
     }
 
@@ -233,10 +249,7 @@ static void submit_callback (flux_future_t *f, void *arg)
         if (!(errstr = flux_future_error_string (f))) {
             errstr = "";
         }
-        flux_log_error (h,
-                        "%" JSON_INTEGER_FORMAT
-                        ": submission to specified Flux instance failed",
-                        *orig_id);
+        flux_log_error (h, "%s: submission to specified Flux instance failed", idf58 (*orig_id));
         flux_jobtap_raise_exception (p, *orig_id, "DelegationFailure", 0, errstr);
         flux_future_destroy (wait_future);
         flux_future_destroy (event_future);
@@ -321,7 +334,7 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
                                        flux_plugin_arg_strerror (args));
     }
     if (!(delegated = flux_open (uri, 0))) {
-        flux_log_error (h, "%" JSON_INTEGER_FORMAT ": could not open URI %s", *id, uri);
+        flux_log_error (h, "%s: could not open URI %s", idf58 (*id), uri);
         return -1;
     }
     if (flux_jobtap_dependency_add (p, *id, "delegated") < 0
@@ -332,7 +345,7 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
                                     (flux_free_f)flux_close)
                < 0
         || flux_set_reactor (delegated, flux_get_reactor (h)) < 0) {
-        flux_log_error (h, "%" JSON_INTEGER_FORMAT ": flux_jobtap_dependency_add", *id);
+        flux_log_error (h, "%s: flux_jobtap_dependency_add", idf58 (*id));
         flux_close (delegated);
         return -1;
     }
@@ -343,10 +356,9 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
         || flux_future_then (jobid_future, -1, submit_callback, p) < 0
         || flux_future_aux_set (jobid_future, "flux::jobid", id, NULL) < 0) {
         flux_log_error (h,
-                        "%" JSON_INTEGER_FORMAT
-                        ": could not delegate job to specified Flux "
+                        "%s: could not delegate job to specified Flux "
                         "instance",
-                        *id);
+                        idf58 (*id));
         flux_future_destroy (jobid_future);
         free (encoded_jobspec);
         return -1;

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -19,6 +19,8 @@
 #include <inttypes.h>
 #include <jansson.h>
 #include <stdint.h>
+#include <limits.h>
+#include <unistd.h>
 
 #include <flux/core.h>
 #include <flux/jobtap.h>
@@ -367,15 +369,134 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
     return 0;
 }
 
-static int sched_cb (flux_plugin_t *p,
-                     const char *topic,
-                     flux_plugin_arg_t *args,
-                     void *arg)
+/*
+ * Continuation callback, invoked when alloc-bypass R has been committed
+ * to the KVS.
+ *
+ * Post the alloc (bypass: true) event for the job.
+ */
+static void alloc_continuation (flux_future_t *f, void *arg)
+{
+    flux_plugin_t *p = arg;
+    flux_jobid_t *id;
+
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    if (!f || !(id = flux_future_aux_get (f, "flux::jobid"))) {
+        flux_log_error (h, "alloc_continuation: failed to get jobid from future");
+        goto done;
+    }
+
+    if (flux_future_get (f, NULL) < 0) {
+        flux_log_error (h, "alloc_continuation: flux_future_get failed for %s", idf58 (*id));
+
+        flux_jobtap_raise_exception (p,
+                                     *id,
+                                     "alloc",
+                                     0,
+                                     "failed to commit R to kvs: %s",
+                                     strerror (errno));
+        goto done;
+    }
+
+    if (flux_jobtap_event_post_pack (p, *id, "alloc", "{s:b}", "bypass", true) < 0) {
+        flux_log_error (h, "alloc_continuation: flux_jobtap_event_post_pack for %s", idf58 (*id));
+        flux_jobtap_raise_exception (p,
+                                     *id,
+                                     "alloc",
+                                     0,
+                                     "failed to post alloc event: %s",
+                                     strerror (errno));
+        goto done;
+    }
+
+done:
+    flux_future_destroy (f);
+}
+
+/*
+ * job.state.sched callback. Generates an alloc-bypass R for the job and passes it to the
+ * job manager. Then starts a KVS transaction to post the R to the KVS. Once that is
+ * complete, the `alloc` event should be posted, but that is handled asynchronously.
+ */
+static int sched_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
 {
     flux_t *h = flux_jobtap_get_flux (p);
     if (!h)
         return -1;
-    flux_log (h, LOG_DEBUG, "in delegate sched_cb");
+    flux_jobid_t *id;
+    flux_jobid_t job_id;
+    flux_kvs_txn_t *txn = NULL;
+    json_t *R = NULL;
+    char key[256];
+    char hostname[HOST_NAME_MAX + 1];
+    flux_future_t *alloc_future = NULL;
+
+    if (!(id = flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "flux::delegate::jobid")))
+        return 0;
+
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN, "{s:I}", "id", &job_id) < 0
+        || gethostname (hostname, sizeof (hostname)) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc",
+                                     0,
+                                     "delegate: unpack: %s",
+                                     flux_plugin_arg_strerror (args));
+        flux_log_error (h, "flux_plugin_arg_unpack for %s", idf58 (job_id));
+        return -1;
+    }
+    // Create a fake R without properties
+    if (!(R = json_pack ("{s:i s:{s:[{s:s s:{s:s}}] s:f s:f s:[s]}}",
+                         "version",
+                         1,
+                         "execution",
+                         "R_lite",
+                         "rank",
+                         "0",
+                         "children",
+                         "core",
+                         "0",
+                         "starttime",
+                         0.0,
+                         "expiration",
+                         0.0,
+                         "nodelist",
+                         hostname))
+        || flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT, "{s:O}", "R", R) < 0) {
+        json_decref (R);
+        flux_log_error (h, "failed to output fake R for %s", idf58 (job_id));
+        return flux_jobtap_raise_exception (p,
+                                            job_id,
+                                            "alloc",
+                                            0,
+                                            "failed to post alloc event: %s",
+                                            strerror (errno));
+    }
+    // Create KVS transaction posting the R
+    if (!(txn = flux_kvs_txn_create ()) || flux_job_kvs_key (key, sizeof (key), job_id, "R") < 0
+        || flux_kvs_txn_pack (txn, 0, key, "O", R) < 0
+        || !(alloc_future = flux_kvs_commit (h, NULL, 0, txn))
+        || flux_future_then (alloc_future, -1, alloc_continuation, p) < 0) {
+        flux_log_error (h, "failed processing R KVS transaction");
+        flux_kvs_txn_destroy (txn);
+        flux_future_destroy (alloc_future);
+        json_decref (R);
+        return flux_jobtap_raise_exception (p,
+                                            job_id,
+                                            "alloc",
+                                            0,
+                                            "failed to post alloc event: %s",
+                                            strerror (errno));
+    }
+    json_decref (R);
+    flux_kvs_txn_destroy (txn);
+    if (flux_future_aux_set (alloc_future, "flux::jobid", id, NULL) < 0) {
+        flux_future_destroy (alloc_future);
+        return flux_jobtap_raise_exception (p, job_id, "alloc", 0, "flux_future_aux_set");
+    }
+    *id = job_id;
+
     return 0;
 }
 

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -326,7 +326,7 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
                                 "jobspec",
                                 &jobspec)
             < 0
-        || flux_jobtap_job_aux_set (p, *id, "flux::jobid", id, free) < 0) {
+        || flux_jobtap_job_aux_set (p, *id, "flux::delegate::jobid", id, free) < 0) {
         free (id);
         return flux_jobtap_reject_job (p,
                                        args,

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -500,19 +500,65 @@ static int sched_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *arg
     return 0;
 }
 
-
-static int run_cb (flux_plugin_t *p,
-                   const char *topic,
-                   flux_plugin_arg_t *args,
-                   void *arg)
+/*
+ * job.state.run callback. Sends `job-exec.override` RPCs to make the job skip
+ * execution, since execution is handled by another Flux instance.
+ */
+static int run_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
 {
     flux_t *h = flux_jobtap_get_flux (p);
+    flux_jobid_t job_id;
+    flux_future_t *run_future;
+
     if (!h)
         return -1;
-    flux_log (h, LOG_DEBUG, "in delegate run_cb");
+
+    if (!flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "flux::delegate::jobid"))
+        return 0;
+
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN, "{s:I}", "id", &job_id) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc",
+                                     0,
+                                     "delegate: unpack: %s",
+                                     flux_plugin_arg_strerror (args));
+        flux_log_error (h, "flux_plugin_arg_unpack");
+        return -1;
+    }
+    // send `job-exec.override` start and finish events. TODO: check the RPC return status
+    // and handle errors.
+    if (!(run_future = flux_rpc_pack (h,
+                                      "job-exec.override",
+                                      FLUX_NODEID_ANY,
+                                      0,
+                                      "{s:s s:I}",
+                                      "event",
+                                      "start",
+                                      "jobid",
+                                      (json_int_t)job_id))) {
+        flux_log_error (h, "flux_rpc_pack failed for %s job-exec.override: start", idf58 (job_id));
+        return -1;
+    }
+    flux_future_destroy (run_future);
+    if (!(run_future = flux_rpc_pack (h,
+                                      "job-exec.override",
+                                      FLUX_NODEID_ANY,
+                                      0,
+                                      "{s:s s:I}",
+                                      "event",
+                                      "finish",
+                                      "jobid",
+                                      (json_int_t)job_id))) {
+        flux_log_error (h,
+                        "flux_rpc_pack failed for %s in job-exec.override: finish",
+                        idf58 (job_id));
+        return -1;
+    }
+    flux_future_destroy (run_future);
+
     return 0;
 }
-
 
 static const struct flux_plugin_handler tab[] = {
     {"job.dependency.delegate", depend_cb, NULL},

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -139,7 +139,7 @@ static int eventlog_entry_parse (json_t *entry,
 static void wait_callback (flux_future_t *f, void *arg)
 {
     flux_plugin_t *p = arg;
-    json_int_t *id;
+    flux_jobid_t *id;
     bool success;
     const char *errstr;
 
@@ -173,8 +173,7 @@ static void event_callback (flux_future_t *f, void *arg)
 {
     flux_plugin_t *p = arg;
     flux_t *h;
-    json_int_t *json_id;
-    flux_jobid_t id;
+    flux_jobid_t *id;
     json_t *o = NULL;
     json_t *context = NULL;
     const char *name = NULL, *event = NULL;
@@ -183,24 +182,23 @@ static void event_callback (flux_future_t *f, void *arg)
     if (!(h = flux_future_aux_get (f, "flux::handle"))) {
         return;
     }
-    if (!(json_id = flux_future_aux_get (f, "flux::jobid"))) {
+    if (!(id = flux_future_aux_get (f, "flux::jobid"))) {
         flux_log_error (h, "could not fetch flux::jobid from future");
         return;
     }
-    id = (flux_jobid_t)*json_id;
     if (flux_job_event_watch_get (f, &event) != 0 || !(o = eventlog_entry_decode (event))
         || eventlog_entry_parse (o, &timestamp, &name, &context) < 0) {
         json_decref (o);
-        flux_log_error (h, "Error decoding/parsing eventlog entry for %s", idf58 (id));
+        flux_log_error (h, "Error decoding/parsing eventlog entry for %s", idf58 (*id));
         return;
     }
     if (!strcmp (name, "start")) {
         /*  'start' event with no cray_port_distribution event.
          *  assume cray-pals jobtap plugin is not loaded.
          */
-        if (flux_jobtap_event_post_pack (p, id, "delegate::start", "{s:f}", "timestamp", timestamp)
+        if (flux_jobtap_event_post_pack (p, *id, "delegate::start", "{s:f}", "timestamp", timestamp)
             < 0) {
-            flux_log_error (h, "could not post delegate::start event for %s", idf58 (id));
+            flux_log_error (h, "could not post delegate::start event for %s", idf58 (*id));
         }
     }
 
@@ -220,8 +218,7 @@ static void submit_callback (flux_future_t *f, void *arg)
 {
     flux_t *h, *delegated_h;
     flux_plugin_t *p = arg;
-    json_int_t *orig_id;
-    flux_jobid_t delegated_id;
+    flux_jobid_t delegated_id, *orig_id;
     flux_future_t *wait_future = NULL, *event_future = NULL;
     const char *errstr;
 
@@ -246,7 +243,7 @@ static void submit_callback (flux_future_t *f, void *arg)
                                         "delegate::submit",
                                         "{s:I}",
                                         "jobid",
-                                        (json_int_t)delegated_id)
+                                        delegated_id)
                < 0) {
         if (!(errstr = flux_future_error_string (f))) {
             errstr = "";
@@ -304,14 +301,14 @@ static char *remove_dependency_and_encode (json_t *jobspec)
 static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
 {
     flux_t *h = flux_jobtap_get_flux (p);
-    json_int_t *id;
+    flux_jobid_t *id;
     flux_t *delegated;
     const char *uri;
     json_t *jobspec;
     char *encoded_jobspec = NULL;
     flux_future_t *jobid_future = NULL;
 
-    if (!h || !(id = malloc (sizeof (json_int_t)))) {
+    if (!h || !(id = malloc (sizeof (flux_jobid_t)))) {
         return flux_jobtap_reject_job (p,
                                        args,
                                        "error processing delegate: %s",
@@ -434,7 +431,6 @@ static int sched_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *arg
     if (!h)
         return -1;
     flux_jobid_t *id;
-    flux_jobid_t job_id;
     flux_kvs_txn_t *txn = NULL;
     json_t *R = NULL;
     char key[256];
@@ -444,15 +440,14 @@ static int sched_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *arg
     if (!(id = flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "flux::delegate::jobid")))
         return 0;
 
-    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN, "{s:I}", "id", &job_id) < 0
-        || gethostname (hostname, sizeof (hostname)) < 0) {
+    if (gethostname (hostname, sizeof (hostname)) < 0) {
         flux_jobtap_raise_exception (p,
                                      FLUX_JOBTAP_CURRENT_JOB,
                                      "alloc",
                                      0,
-                                     "delegate: unpack: %s",
+                                     "delegate: gethostname: %s",
                                      flux_plugin_arg_strerror (args));
-        flux_log_error (h, "flux_plugin_arg_unpack for %s", idf58 (job_id));
+        flux_log_error (h, "gethostname for %s", idf58 (*id));
         return -1;
     }
     // Create a fake R without properties
@@ -474,16 +469,16 @@ static int sched_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *arg
                          hostname))
         || flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT, "{s:O}", "R", R) < 0) {
         json_decref (R);
-        flux_log_error (h, "failed to output fake R for %s", idf58 (job_id));
+        flux_log_error (h, "failed to output fake R for %s", idf58 (*id));
         return flux_jobtap_raise_exception (p,
-                                            job_id,
+                                            *id,
                                             "alloc",
                                             0,
                                             "failed to post alloc event: %s",
                                             strerror (errno));
     }
     // Create KVS transaction posting the R
-    if (!(txn = flux_kvs_txn_create ()) || flux_job_kvs_key (key, sizeof (key), job_id, "R") < 0
+    if (!(txn = flux_kvs_txn_create ()) || flux_job_kvs_key (key, sizeof (key), *id, "R") < 0
         || flux_kvs_txn_pack (txn, 0, key, "O", R) < 0
         || !(alloc_future = flux_kvs_commit (h, NULL, 0, txn))
         || flux_future_then (alloc_future, -1, alloc_continuation, p) < 0) {
@@ -492,7 +487,7 @@ static int sched_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *arg
         flux_future_destroy (alloc_future);
         json_decref (R);
         return flux_jobtap_raise_exception (p,
-                                            job_id,
+                                            *id,
                                             "alloc",
                                             0,
                                             "failed to post alloc event: %s",
@@ -502,9 +497,8 @@ static int sched_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *arg
     flux_kvs_txn_destroy (txn);
     if (flux_future_aux_set (alloc_future, "flux::jobid", id, NULL) < 0) {
         flux_future_destroy (alloc_future);
-        return flux_jobtap_raise_exception (p, job_id, "alloc", 0, "flux_future_aux_set");
+        return flux_jobtap_raise_exception (p, *id, "alloc", 0, "flux_future_aux_set");
     }
-    *id = job_id;
 
     return 0;
 }
@@ -545,7 +539,7 @@ static int run_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args,
                                       "event",
                                       "start",
                                       "jobid",
-                                      (json_int_t)job_id))) {
+                                      job_id))) {
         flux_log_error (h, "flux_rpc_pack failed for %s job-exec.override: start", idf58 (job_id));
         return -1;
     }
@@ -558,7 +552,7 @@ static int run_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args,
                                       "event",
                                       "finish",
                                       "jobid",
-                                      (json_int_t)job_id))) {
+                                      job_id))) {
         flux_log_error (h,
                         "flux_rpc_pack failed for %s in job-exec.override: finish",
                         idf58 (job_id));

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -137,15 +137,19 @@ static void wait_callback (flux_future_t *f, void *arg)
         return;
     }
     if (success) {
-        flux_jobtap_raise_exception (p, *id, "DelegationSuccess", 0, "");
-    } else {
-        flux_jobtap_raise_exception (p,
-                                     *id,
-                                     "DelegationFailure",
-                                     0,
-                                     "errstr %s",
-                                     errstr);
+        if (flux_jobtap_dependency_remove (p, *id, "delegated") < 0) {
+            errstr = "failed to remove dependency";
+        } else {
+            flux_future_destroy (f);
+            return;
+        }
     }
+    flux_jobtap_raise_exception (p,
+                                 *id,
+                                 "DelegationFailure",
+                                 0,
+                                 "errstr %s",
+                                 errstr);
     flux_future_destroy (f);
 }
 
@@ -368,8 +372,36 @@ static int depend_cb (flux_plugin_t *p,
     return 0;
 }
 
+static int sched_cb (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+    if (!h)
+        return -1;
+    flux_log (h, LOG_DEBUG, "in delegate sched_cb");
+    return 0;
+}
+
+
+static int run_cb (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *arg)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+    if (!h)
+        return -1;
+    flux_log (h, LOG_DEBUG, "in delegate run_cb");
+    return 0;
+}
+
+
 static const struct flux_plugin_handler tab[] = {
     {"job.dependency.delegate", depend_cb, NULL},
+    {"job.state.sched", sched_cb, NULL},
+    {"job.state.run", run_cb, NULL},
     {0},
 };
 


### PR DESCRIPTION
Problem: the delegate jobtap plugin currently raises an exception
on a job once its delegated copy has completed. However, that makes
it difficult for users to distinguish successfully delegated jobs
from unsuccessfully delegated ones.

Instead of raising an exception, remove the `delegate` dependency,
to allow the job to transition to a normal and successful completion
state. Then use the alloc-bypass functionality and exec-bypass RPC
to make the job skip the scheduler and execution systems.