### PR TITLE
Move to priority based delegation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,22 @@ jobs:
     - name: Check Spelling
       uses: crate-ci/typos@v1.44.0
 
+  code-format:
+    name: code formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: actions/checkout@v6.0.2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: install pre-commit
+      run: pip install pre-commit
+    - name: format and linting checks
+      run: pre-commit run --all-files --show-diff-on-failure
+
   check-el9:
     name: el9 checks
     runs-on: ubuntu-latest

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,35 @@
+queue_rules:
+  - name: default
+    batch_size: 1
+    update_method: rebase
+    merge_method: merge
+
+# Avoid temporary branches created by mergify for parallel checks.
+# These do not work with the pr-validator since the temporary PR
+# branch is updated with a merge commit.
+merge_queue:
+  max_parallel_checks: 1
+
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=main
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - -title~=^\[*[Ww][Ii][Pp]
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      queue:
+        name: default
+  - name: remove outdated approved reviews
+    conditions:
+      - author!=@core
+    actions:
+      dismiss_reviews:
+        approved: true
+        changes_requested: false
+        message: |
+          Approving reviews have been dismissed because this pull request
+          was updated.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+files: '^(src|t)/.*(\.py|\.h|\.hpp|\.c|\.cpp)'
+exclude: "^(.*((pyco|lib)tap|yggdrasil|jsongraph).*)$"
+repos:
+  - repo: meta
+    hooks:
+    - id: identity
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-shebang-scripts-are-executable
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.1
+    hooks:
+      # Run the linter.
+      - id: ruff
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [ python, pyi ]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    # this is the release of 18.1.6
+    rev: 'eb7205de69febb10d8d455ed9cc0a9fa6ac3a17a'
+    hooks:
+    -   id: clang-format

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The `delegate.so` plugin will be installed in `<install-path>/lib/flux/job-manag
 
 If an `<install-path>` is specified, it is also installed in `flux-multi-cluster-utilities/src/job-manager/plugins/.libs`.
 
+Supported delegation policies are `random`, `least_pending`, `shortest_match`,
+and `assign`.
+
 ### Loading a JobTap Plugin
 The plugin can be loaded with the command below. 
 Note that an absolute path needs to be specified here. 
@@ -173,6 +176,12 @@ the instance can be created across core-granularities, as shown below, on a sing
 ```
 flux submit -n1 -c2 flux start sleep inf
 ```
+
+### Example Scripts
+
+The [examples/](examples) directory contains standalone scripts demonstrating
+delegation policies. See [examples/README.md](examples/README.md) for a full
+description of each script.
 
 ### Upcoming Research
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# Example Scripts
+
+This directory contains standalone scripts that demonstrate the delegation
+policies supported by the `delegate.so` jobtap plugin. Each script sets up a
+self-contained multi-instance Flux environment and exercises a specific
+delegation workflow.
+
+## assign-delegation-3instances.sh
+
+Sets up a 4-node allocation in pdebug partition and launches one source 
+Flux instance on a single node alongside three target Flux instances 
+on the remaining nodes. It then demonstrates the **`assign`** delegation policy 
+by submitting a job from the source instance that is deterministically routed 
+to a specific target instance by index.
+
+Key steps performed by the script:
+
+1. Allocates 4 nodes and starts a 1-node source Flux instance.
+2. Starts 1-node target Flux instances each of the remaining nodes.
+3. Loads the delegate configuration with a list of remote target URIs and the
+   `delegate.so` plugin into the source Flux instance.
+4. Submits a job using `--dependency=delegate:assign:2` to target the third
+   entry (index 2) in the delegation list.
+5. Verifies that the delegated job landed on the expected target instance.
+
+
+Run it from the source root as:
+
+```bash
+bash examples/assign-delegation-3instances.sh
+```

--- a/examples/assign-delegation-3instances.sh
+++ b/examples/assign-delegation-3instances.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# This script allocates 4 nodes in the pdebug partition, 
+# starts a source Flux instance on 1 node and 3 target Flux instances 
+# on the other 3 nodes, then demonstrates the "assign" delegation policy
+# from the Flux delegate plugin by submitting a job to the source instance 
+# that gets delegated to a specific target instance based on its index 
+# in the delegate configuration.
+#
+# Run it as:
+#   bash examples/assign-delegation-3instances.sh
+
+PLUGIN_PATH="${PWD}/src/job-manager/plugins/.libs/delegate.so"
+CONFIG_FILE="${PWD}/examples/assign-delegate-config.toml"
+SOURCE_INSTANCE=""
+TARGET0_ID=""
+TARGET1_ID=""
+TARGET2_ID=""
+
+cleanup() {
+    set +e
+    [[ -n "${SOURCE_INSTANCE}" ]] && flux cancel "${SOURCE_INSTANCE}" >/dev/null 2>&1 || true
+    flux cancel "${TARGET0_ID}" "${TARGET1_ID}" "${TARGET2_ID}" >/dev/null 2>&1 || true
+    rm -f "${CONFIG_FILE}"
+}
+trap cleanup EXIT
+
+if [[ ! -f "${PLUGIN_PATH}" ]]; then
+    echo "delegate plugin not found at ${PLUGIN_PATH}" >&2
+    exit 1
+fi
+
+printf '[1/5] Starting 1-node source instance on a 4-node allocation...\n'
+SOURCE_INSTANCE="$(flux batch --queue=pdebug -N1 -n1 -t120s --wrap sleep inf | tail -n 1 | tr -d '[:space:]')"
+flux job wait-event "${SOURCE_INSTANCE}" start
+
+printf '[2/5] Starting three 1-node target instances...\n'
+TARGET0_ID="$(flux batch --queue=pdebug -N1 -n1 -t120s --wrap sleep inf | tail -n 1 | tr -d '[:space:]')"
+flux job wait-event "${TARGET0_ID}" start
+TARGET1_ID="$(flux batch --queue=pdebug -N1 -n1 -t120s --wrap sleep inf | tail -n 1 | tr -d '[:space:]')"
+flux job wait-event "${TARGET1_ID}" start
+TARGET2_ID="$(flux batch --queue=pdebug -N1 -n1 -t120s --wrap sleep inf | tail -n 1 | tr -d '[:space:]')"
+flux job wait-event "${TARGET2_ID}" start
+
+TARGET0_URI="$(flux uri --remote "${TARGET0_ID}")"
+TARGET1_URI="$(flux uri --remote "${TARGET1_ID}")"
+TARGET2_URI="$(flux uri --remote "${TARGET2_ID}")"
+
+printf '[3/5] Loading delegate configuration into the source instance...\n'
+printf 'delegate = [ "%s", "%s", "%s" ]\n' "${TARGET0_URI}" "${TARGET1_URI}" "${TARGET2_URI}" > "${CONFIG_FILE}"
+cat "${CONFIG_FILE}" | flux proxy "${SOURCE_INSTANCE}" flux config load
+flux proxy "${SOURCE_INSTANCE}" flux jobtap load "${PLUGIN_PATH}"
+
+printf '[4/5] Submitting with assign policy to target index 2.\n'
+JOB_ID="$(flux proxy "${SOURCE_INSTANCE}" flux submit --dependency=delegate:assign:2 -t60s hostname | tail -n 1 | tr -d '[:space:]')"
+flux proxy "${SOURCE_INSTANCE}" flux job wait-event --timeout=60s "${JOB_ID}" clean
+
+DELEGATED_ID="$(flux proxy "${SOURCE_INSTANCE}" flux job eventlog "${JOB_ID}" |
+	sed -nE '/delegate::submit/ s/.*jobid["=:[:space:]]+("?)([^",}[:space:]]+).*/\2/p' |
+	head -n 1)"
+
+printf '[5/5] Verifying delegated job landed on target index 2...\n'
+flux proxy "${SOURCE_INSTANCE}" flux job eventlog "${JOB_ID}" | grep -q 'delegate::submit'
+flux proxy "${TARGET2_URI}" flux jobs --format="{id}" "${DELEGATED_ID}" >/dev/null 2>&1
+printf 'PASS: assign policy delegated job %s to target[2] (%s).\n' "${JOB_ID}" "${TARGET2_ID}"

--- a/src/common/libutil/idf58.h
+++ b/src/common/libutil/idf58.h
@@ -23,7 +23,7 @@ static inline const char *idf58 (flux_jobid_t id)
         /* 64bit integer is guaranteed to fit in 21 bytes
          * floor(log(2^64-1)/log(1)) + 1 = 20
          */
-        (void) sprintf (buf, "%ju", (uintmax_t) id);
+        (void)sprintf (buf, "%ju", (uintmax_t)id);
     }
     return buf;
 }

--- a/src/common/select/select.c
+++ b/src/common/select/select.c
@@ -127,16 +127,12 @@ void selection_destroy (struct cluster_config *config)
     free (config);
 }
 
-static bool selection_has_clusters (struct cluster_config *config,
-                                    const char *strategy_name)
+static bool selection_has_clusters (struct cluster_config *config, const char *strategy_name)
 {
     if (!config || config->count == 0) {
         errno = ENOENT;
         if (config) {
-            flux_log (config->h,
-                      LOG_ERR,
-                      "No clusters available for %s",
-                      strategy_name);
+            flux_log (config->h, LOG_ERR, "No clusters available for %s", strategy_name);
         }
         return false;
     }
@@ -185,7 +181,8 @@ static int query_max_match_time (flux_t *h, const char *uri, double *value)
         flux_log (h, LOG_ERR, "Failed to open flux instance %s", uri);
         goto out;
     }
-    if (!(future = flux_rpc (remote, "sched-fluxion-resource.stats-get", NULL, FLUX_NODEID_ANY, 0))) {
+    if (!(future =
+              flux_rpc (remote, "sched-fluxion-resource.stats-get", NULL, FLUX_NODEID_ANY, 0))) {
         flux_log (h, LOG_ERR, "Failed to query match statistics for %s", uri);
         goto out;
     }
@@ -206,7 +203,7 @@ static int query_max_match_time (flux_t *h, const char *uri, double *value)
                              &max,
                              "avg",
                              &avg)
-            < 0) {
+        < 0) {
         flux_log (h, LOG_ERR, "Failed to unpack match statistics for %s", uri);
         goto out;
     }
@@ -234,7 +231,8 @@ static int query_pending_jobs (flux_t *h, const char *uri, int64_t *value)
         flux_log (h, LOG_ERR, "Failed to open flux instance %s", uri);
         goto out;
     }
-    if (!(future = flux_rpc (remote, "sched-fluxion-qmanager.stats-get", NULL, FLUX_NODEID_ANY, 0))) {
+    if (!(future =
+              flux_rpc (remote, "sched-fluxion-qmanager.stats-get", NULL, FLUX_NODEID_ANY, 0))) {
         flux_log (h, LOG_ERR, "Failed to query queue statistics for %s", uri);
         goto out;
     }
@@ -248,7 +246,7 @@ static int query_pending_jobs (flux_t *h, const char *uri, int64_t *value)
                              "scheduled_queues",
                              "running",
                              &running)
-            < 0) {
+        < 0) {
         flux_log (h, LOG_ERR, "Failed to unpack queue statistics for %s", uri);
         goto out;
     }
@@ -272,13 +270,13 @@ static int query_cluster_metric (flux_t *h,
 
     metric->kind = kind;
     switch (kind) {
-    case SELECTION_METRIC_MATCH_TIME:
-        return query_max_match_time (h, uri, &metric->value.match_time);
-    case SELECTION_METRIC_PENDING_JOBS:
-        return query_pending_jobs (h, uri, &metric->value.pending_jobs);
-    default:
-        errno = EINVAL;
-        return -1;
+        case SELECTION_METRIC_MATCH_TIME:
+            return query_max_match_time (h, uri, &metric->value.match_time);
+        case SELECTION_METRIC_PENDING_JOBS:
+            return query_pending_jobs (h, uri, &metric->value.pending_jobs);
+        default:
+            errno = EINVAL;
+            return -1;
     }
 }
 
@@ -305,11 +303,7 @@ static const char *select_cluster_by_metric (struct cluster_config *config,
     for (index = 0; index < config->count; index++) {
         struct selection_metric metric;
 
-        if (query_cluster_metric (config->h,
-                                  config->uris[index],
-                                  best_metric->kind,
-                                  &metric)
-                < 0)
+        if (query_cluster_metric (config->h, config->uris[index], best_metric->kind, &metric) < 0)
             continue;
         if (!best_uri || selection_metric_is_better (&metric, best_metric)) {
             *best_metric = metric;
@@ -331,7 +325,8 @@ static const char *select_shortest_match_cluster (struct cluster_config *config)
     };
     const char *best_uri = select_cluster_by_metric (config,
                                                      "shortest_match",
-                                                     "Unable to compute shortest_match for any cluster",
+                                                     "Unable to compute shortest_match for any "
+                                                     "cluster",
                                                      &best_metric);
 
     if (!best_uri) {
@@ -353,7 +348,8 @@ static const char *select_least_pending_cluster (struct cluster_config *config)
     };
     const char *best_uri = select_cluster_by_metric (config,
                                                      "least_pending",
-                                                     "Unable to compute least_pending for any cluster",
+                                                     "Unable to compute least_pending for any "
+                                                     "cluster",
                                                      &best_metric);
 
     if (!best_uri) {
@@ -381,4 +377,3 @@ const char *select_cluster (struct cluster_config *config, const char *strategy)
         return select_shortest_match_cluster (config);
     return NULL;
 }
-

--- a/src/common/select/select.c
+++ b/src/common/select/select.c
@@ -8,7 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#include <ctype.h>
 #include <errno.h>
+#include <float.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -77,6 +80,10 @@ static int load_config (struct cluster_config *config)
     }
 
     config->count = json_array_size (delegate);
+    if (config->count == 0) {
+        config->uris = NULL;
+        return 0;
+    }
     if (!(config->uris = calloc (config->count, sizeof (char *)))) {
         flux_log_error (config->h, "calloc");
         return -1;
@@ -94,6 +101,7 @@ static int load_config (struct cluster_config *config)
             goto error;
         }
     }
+
     return 0;
 error:
     config->count = index;
@@ -363,6 +371,49 @@ static const char *select_least_pending_cluster (struct cluster_config *config)
     return best_uri;
 }
 
+static const char *select_assign_cluster (struct cluster_config *config, const char *strategy)
+{
+    size_t idx = 0;
+    const char *suffix;
+    char *endptr;
+    unsigned long val;
+
+    if (!selection_has_clusters (config, "assign"))
+        return NULL;
+
+    suffix = strchr (strategy, ':');
+    if (suffix) {
+        errno = 0;
+        val = strtoul (suffix + 1, &endptr, 10);
+        if (errno != 0 || *endptr != '\0' || val > SIZE_MAX) {
+            flux_log (config->h,
+                      LOG_ERR,
+                      "assign: invalid sub-instance ID '%s': %s",
+                      suffix + 1,
+                      strerror (errno));
+            return NULL;
+        }
+        idx = (size_t)val;
+    }
+
+    if (idx >= config->count) {
+        flux_log (config->h,
+                  LOG_ERR,
+                  "assign: sub-instance ID %zu out of range (0..%zu)",
+                  idx,
+                  config->count - 1);
+        errno = ERANGE;
+        return NULL;
+    }
+
+    flux_log (config->h,
+              LOG_INFO,
+              "Selected cluster %zu by assign policy: %s",
+              idx,
+              config->uris[idx]);
+    return config->uris[idx];
+}
+
 const char *select_cluster (struct cluster_config *config, const char *strategy)
 {
     if (!config) {
@@ -375,5 +426,7 @@ const char *select_cluster (struct cluster_config *config, const char *strategy)
         return select_least_pending_cluster (config);
     if (strcmp (strategy, "shortest_match") == 0)
         return select_shortest_match_cluster (config);
+    if (strncmp (strategy, "assign", 6) == 0)
+        return select_assign_cluster (config, strategy);
     return NULL;
 }

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -206,10 +206,7 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
     struct cluster_config *config;
 
     if (!h || !(id = malloc (sizeof (flux_jobid_t)))) {
-        return flux_jobtap_reject_job (p,
-                                       args,
-                                       "error processing delegate: %s",
-                                       strerror (errno));
+        return flux_jobtap_reject_job (p, args, "error processing delegate: %s", strerror (errno));
     }
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
@@ -477,10 +474,12 @@ int flux_plugin_init (flux_plugin_t *p)
     struct cluster_config *config;
     flux_t *h = flux_jobtap_get_flux (p);
 
-    if (!h
-        || flux_plugin_register (p, "delegate", tab) < 0
-        || !(config = selection_init(h))
-        || flux_plugin_aux_set (p, "flux::delegate::selection_config", config, (flux_free_f)selection_destroy) < 0) {
+    if (!h || flux_plugin_register (p, "delegate", tab) < 0 || !(config = selection_init (h))
+        || flux_plugin_aux_set (p,
+                                "flux::delegate::selection_config",
+                                config,
+                                (flux_free_f)selection_destroy)
+               < 0) {
         return -1;
     }
     return 0;

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -51,8 +51,8 @@ static void wait_callback (flux_future_t *f, void *arg)
         return;
     }
     if (success) {
-        if (flux_jobtap_dependency_remove (p, *id, "delegated") < 0) {
-            errstr = "failed to remove dependency";
+        if (flux_jobtap_reprioritize_job (p, *id, 16) < 0) {
+            errstr = "failed to update priority";
         } else {
             flux_future_destroy (f);
             return;
@@ -154,71 +154,24 @@ static void submit_callback (flux_future_t *f, void *arg)
     flux_future_destroy (f);
 }
 
-/*
- * Remove all dependencies from jobspec.
- *
- * Dependencies may reference jobids that the instance the job is
- * being sent to does not recognize.
- *
- * Also, if the 'delegate' dependency in particular were not removed,
- * one of two things would happen. If the instance the job is sent to
- * does not have this jobtap plugin loaded, then the job would be
- * rejected. Otherwise, if the instance DOES have this jobtap plugin
- * loaded, it would attempt to delegate to itself in an infinite
- * loop.
- */
-static char *remove_dependency_and_encode (json_t *jobspec)
-{
-    char *encoded_jobspec;
-    json_t *dependency_list = NULL;
-
-    if (!(jobspec = json_deep_copy (jobspec))) {
-        return NULL;
-    }
-    if (json_unpack (jobspec,
-                     "{s:{s:{s:o}}}",
-                     "attributes",
-                     "system",
-                     "dependencies",
-                     &dependency_list)
-            < 0
-        || json_array_clear (dependency_list) < 0) {
-        json_decref (jobspec);
-        return NULL;
-    }
-    encoded_jobspec = json_dumps (jobspec, 0);
-    json_decref (jobspec);
-    return encoded_jobspec;
-}
-
-/*
- * Handle job.dependency.delegate requests
- */
-static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
+static int priority_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
 {
     flux_t *h = flux_jobtap_get_flux (p);
     flux_jobid_t *id;
     flux_t *delegated;
-    const char *uri, *strategy = NULL;
+    const char *uri, *strategy = "random";
     json_t *jobspec;
-    char *encoded_jobspec = NULL;
     flux_future_t *jobid_future = NULL;
     struct cluster_config *config;
 
     if (!h || !(id = malloc (sizeof (flux_jobid_t)))) {
-        return flux_jobtap_reject_job (p,
-                                       args,
-                                       "error processing delegate: %s",
-                                       strerror (errno));
+        return flux_jobtap_reject_job (p, args, "error processing delegate: %s", strerror (errno));
     }
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s:I s:{s?s} s:o}",
+                                "{s:I s:o}",
                                 "id",
                                 id,
-                                "dependency",
-                                "value",
-                                &strategy,
                                 "jobspec",
                                 &jobspec)
             < 0
@@ -238,7 +191,7 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
         flux_log_error (h, "%s: could not open URI %s", idf58 (*id), uri);
         return -1;
     }
-    if (flux_jobtap_dependency_add (p, *id, "delegated") < 0
+    if (flux_jobtap_reprioritize_job (p, *id, 0) < 0
         || flux_jobtap_job_aux_set (p,
                                     *id,
                                     "flux::delegated_handle",
@@ -261,8 +214,7 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
                                      strerror (errno));
         return -1;
     }
-    if (!(encoded_jobspec = remove_dependency_and_encode (jobspec))
-        || !(jobid_future = flux_job_submit (delegated, encoded_jobspec, 16, FLUX_JOB_WAITABLE))
+    if (!(jobid_future = flux_job_submit (delegated, json_dumps(jobspec,0), 16, FLUX_JOB_WAITABLE))
         || flux_future_then (jobid_future, -1, submit_callback, p) < 0
         || flux_future_aux_set (jobid_future, "flux::jobid", id, NULL) < 0) {
         flux_log_error (h,
@@ -270,10 +222,10 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
                         "instance",
                         idf58 (*id));
         flux_future_destroy (jobid_future);
-        free (encoded_jobspec);
+        // free (jobspec);
         return -1;
     }
-    free (encoded_jobspec);
+    // free (jobspec);
     return 0;
 }
 
@@ -466,9 +418,9 @@ static int run_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args,
 }
 
 static const struct flux_plugin_handler tab[] = {
-    {"job.dependency.delegate", depend_cb, NULL},
     {"job.state.sched", sched_cb, NULL},
     {"job.state.run", run_cb, NULL},
+    {"job.state.priority", priority_cb, NULL},
     {0},
 };
 
@@ -477,10 +429,12 @@ int flux_plugin_init (flux_plugin_t *p)
     struct cluster_config *config;
     flux_t *h = flux_jobtap_get_flux (p);
 
-    if (!h
-        || flux_plugin_register (p, "delegate", tab) < 0
-        || !(config = selection_init(h))
-        || flux_plugin_aux_set (p, "flux::delegate::selection_config", config, (flux_free_f)selection_destroy) < 0) {
+    if (!h || flux_plugin_register (p, "delegate", tab) < 0 || !(config = selection_init (h))
+        || flux_plugin_aux_set (p,
+                                "flux::delegate::selection_config",
+                                config,
+                                (flux_free_f)selection_destroy)
+               < 0) {
         return -1;
     }
     return 0;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -19,7 +19,8 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 # Test scripts
 TESTSCRIPTS = \
 	t0000-sharness.t \
-	t1000-delegate-load.t
+	t1000-delegate-load.t \
+	t1001-delegate-assign.t
 
 # dist_check_SCRIPTS are built and installed for 'make distcheck'
 dist_check_SCRIPTS = \

--- a/t/scripts/run_timeout.py
+++ b/t/scripts/run_timeout.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """run command with a timeout, timeout as a float is first argument, rest are command"""
+
 import argparse
 import os
 import signal

--- a/t/sharness.d/01-setup.sh
+++ b/t/sharness.d/01-setup.sh
@@ -25,7 +25,7 @@ if test -z "$FLUX_BUILD_DIR"; then
     if test -z "${builddir}"; then
         FLUX_BUILD_DIR="$(cd .. && pwd)"
     else
-        FLUX_BUILD_DIR="$(cd ${builddir}/.. && pwd))"
+        FLUX_BUILD_DIR="$(cd ${builddir}/.. && pwd)"
     fi
     export FLUX_BUILD_DIR
 fi

--- a/t/t1001-delegate-assign.t
+++ b/t/t1001-delegate-assign.t
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+test_description='Test assign delegation policy for deterministic target selection'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 3
+
+test_expect_success 'start two target sub-instances' '
+	target_0=$(flux batch -n1 -t120s --wrap sleep inf) &&
+	flux job wait-event ${target_0} start &&
+	target_1=$(flux batch -n1 -t120s --wrap sleep inf) &&
+	flux job wait-event ${target_1} start
+'
+
+test_expect_success 'configure delegate plugin with two target URIs' '
+	uri_0=$(flux uri --local ${target_0}) &&
+	uri_1=$(flux uri --local ${target_1}) &&
+	printf "delegate = [ \"%s\", \"%s\" ]\n" "${uri_0}" "${uri_1}" |
+		flux config load && flux config get | jq -e .
+'
+
+test_expect_success 'plugin can be loaded' '
+	flux jobtap load "${SHARNESS_TEST_SRCDIR}"/../src/job-manager/plugins/.libs/delegate.so &&
+	flux jobtap list | grep delegate.so
+'
+
+test_expect_success 'assign chooses the requested target' '
+	jobid=$(flux submit --dependency=delegate:assign:1 hostname) &&
+	flux job wait-event --timeout=60 ${jobid} clean &&
+	flux job eventlog ${jobid} | grep -q "delegate::submit" &&
+	delegated_id=$(flux job eventlog ${jobid} |
+		sed -nE "/delegate::submit/ s/.*jobid[\"=:[:space:]]+(\"?)([^\",}[:space:]]+).*/\2/p" |
+		head -n 1) &&
+	flux proxy ${uri_1} flux jobs --format="{id}" "${delegated_id}" >/dev/null 2>&1
+'
+
+test_expect_success 'assign rejects invalid target indices' '
+	test_must_fail flux submit --dependency=delegate:assign:2 hostname
+'
+
+test_expect_success 'unload delegate plugin' '
+	flux jobtap remove delegate.so
+'
+
+test_expect_success 'cancel subinstances' '
+	flux cancel --all
+'
+
+test_done


### PR DESCRIPTION
This PR implements the approach discussed in #20 to transition from **dependency-based delegation** to **priority-based delegation**.

### What changed
- Jobs are now paused by setting their priority to `0` via  `flux_jobtap_reprioritize_job`, rather than relying on dependencies.
- Once a job completes in the **TARGET** cluster, it is reprioritized  back to the default stage.

### Why?
The dependency-based approach requires modifying a job's jobspec to remove dependencies containing **"delegate"**. To keep things simple, we currently strip *all* dependencies in that process, which is heavy-handed.

The priority-based approach is cleaner: it requires **no modification to the jobspec**, keeping the whole delegation process as transparent as possible.
