### PR TITLE
style: add pre-commit config and automated checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,22 @@ jobs:
     - name: Check Spelling
       uses: crate-ci/typos@v1.44.0
 
+  code-format:
+    name: code formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: actions/checkout@v6.0.2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: install pre-commit
+      run: pip install pre-commit
+    - name: format and linting checks
+      run: pre-commit run --all-files --show-diff-on-failure
+
   check-el9:
     name: el9 checks
     runs-on: ubuntu-latest

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,35 @@
+queue_rules:
+  - name: default
+    batch_size: 1
+    update_method: rebase
+    merge_method: merge
+
+# Avoid temporary branches created by mergify for parallel checks.
+# These do not work with the pr-validator since the temporary PR
+# branch is updated with a merge commit.
+merge_queue:
+  max_parallel_checks: 1
+
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=main
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - -title~=^\[*[Ww][Ii][Pp]
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      queue:
+        name: default
+  - name: remove outdated approved reviews
+    conditions:
+      - author!=@core
+    actions:
+      dismiss_reviews:
+        approved: true
+        changes_requested: false
+        message: |
+          Approving reviews have been dismissed because this pull request
+          was updated.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+files: '^(src|t)/.*(\.py|\.h|\.hpp|\.c|\.cpp)'
+exclude: "^(.*((pyco|lib)tap|yggdrasil|jsongraph).*)$"
+repos:
+  - repo: meta
+    hooks:
+    - id: identity
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-shebang-scripts-are-executable
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.1
+    hooks:
+      # Run the linter.
+      - id: ruff
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [ python, pyi ]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    # this is the release of 18.1.6
+    rev: 'eb7205de69febb10d8d455ed9cc0a9fa6ac3a17a'
+    hooks:
+    -   id: clang-format

--- a/src/common/libutil/idf58.h
+++ b/src/common/libutil/idf58.h
@@ -23,7 +23,7 @@ static inline const char *idf58 (flux_jobid_t id)
         /* 64bit integer is guaranteed to fit in 21 bytes
          * floor(log(2^64-1)/log(1)) + 1 = 20
          */
-        (void) sprintf (buf, "%ju", (uintmax_t) id);
+        (void)sprintf (buf, "%ju", (uintmax_t)id);
     }
     return buf;
 }

--- a/src/common/select/select.c
+++ b/src/common/select/select.c
@@ -127,16 +127,12 @@ void selection_destroy (struct cluster_config *config)
     free (config);
 }
 
-static bool selection_has_clusters (struct cluster_config *config,
-                                    const char *strategy_name)
+static bool selection_has_clusters (struct cluster_config *config, const char *strategy_name)
 {
     if (!config || config->count == 0) {
         errno = ENOENT;
         if (config) {
-            flux_log (config->h,
-                      LOG_ERR,
-                      "No clusters available for %s",
-                      strategy_name);
+            flux_log (config->h, LOG_ERR, "No clusters available for %s", strategy_name);
         }
         return false;
     }
@@ -185,7 +181,8 @@ static int query_max_match_time (flux_t *h, const char *uri, double *value)
         flux_log (h, LOG_ERR, "Failed to open flux instance %s", uri);
         goto out;
     }
-    if (!(future = flux_rpc (remote, "sched-fluxion-resource.stats-get", NULL, FLUX_NODEID_ANY, 0))) {
+    if (!(future =
+              flux_rpc (remote, "sched-fluxion-resource.stats-get", NULL, FLUX_NODEID_ANY, 0))) {
         flux_log (h, LOG_ERR, "Failed to query match statistics for %s", uri);
         goto out;
     }
@@ -206,7 +203,7 @@ static int query_max_match_time (flux_t *h, const char *uri, double *value)
                              &max,
                              "avg",
                              &avg)
-            < 0) {
+        < 0) {
         flux_log (h, LOG_ERR, "Failed to unpack match statistics for %s", uri);
         goto out;
     }
@@ -234,7 +231,8 @@ static int query_pending_jobs (flux_t *h, const char *uri, int64_t *value)
         flux_log (h, LOG_ERR, "Failed to open flux instance %s", uri);
         goto out;
     }
-    if (!(future = flux_rpc (remote, "sched-fluxion-qmanager.stats-get", NULL, FLUX_NODEID_ANY, 0))) {
+    if (!(future =
+              flux_rpc (remote, "sched-fluxion-qmanager.stats-get", NULL, FLUX_NODEID_ANY, 0))) {
         flux_log (h, LOG_ERR, "Failed to query queue statistics for %s", uri);
         goto out;
     }
@@ -248,7 +246,7 @@ static int query_pending_jobs (flux_t *h, const char *uri, int64_t *value)
                              "scheduled_queues",
                              "running",
                              &running)
-            < 0) {
+        < 0) {
         flux_log (h, LOG_ERR, "Failed to unpack queue statistics for %s", uri);
         goto out;
     }
@@ -272,13 +270,13 @@ static int query_cluster_metric (flux_t *h,
 
     metric->kind = kind;
     switch (kind) {
-    case SELECTION_METRIC_MATCH_TIME:
-        return query_max_match_time (h, uri, &metric->value.match_time);
-    case SELECTION_METRIC_PENDING_JOBS:
-        return query_pending_jobs (h, uri, &metric->value.pending_jobs);
-    default:
-        errno = EINVAL;
-        return -1;
+        case SELECTION_METRIC_MATCH_TIME:
+            return query_max_match_time (h, uri, &metric->value.match_time);
+        case SELECTION_METRIC_PENDING_JOBS:
+            return query_pending_jobs (h, uri, &metric->value.pending_jobs);
+        default:
+            errno = EINVAL;
+            return -1;
     }
 }
 
@@ -305,11 +303,7 @@ static const char *select_cluster_by_metric (struct cluster_config *config,
     for (index = 0; index < config->count; index++) {
         struct selection_metric metric;
 
-        if (query_cluster_metric (config->h,
-                                  config->uris[index],
-                                  best_metric->kind,
-                                  &metric)
-                < 0)
+        if (query_cluster_metric (config->h, config->uris[index], best_metric->kind, &metric) < 0)
             continue;
         if (!best_uri || selection_metric_is_better (&metric, best_metric)) {
             *best_metric = metric;
@@ -331,7 +325,8 @@ static const char *select_shortest_match_cluster (struct cluster_config *config)
     };
     const char *best_uri = select_cluster_by_metric (config,
                                                      "shortest_match",
-                                                     "Unable to compute shortest_match for any cluster",
+                                                     "Unable to compute shortest_match for any "
+                                                     "cluster",
                                                      &best_metric);
 
     if (!best_uri) {
@@ -353,7 +348,8 @@ static const char *select_least_pending_cluster (struct cluster_config *config)
     };
     const char *best_uri = select_cluster_by_metric (config,
                                                      "least_pending",
-                                                     "Unable to compute least_pending for any cluster",
+                                                     "Unable to compute least_pending for any "
+                                                     "cluster",
                                                      &best_metric);
 
     if (!best_uri) {
@@ -381,4 +377,3 @@ const char *select_cluster (struct cluster_config *config, const char *strategy)
         return select_shortest_match_cluster (config);
     return NULL;
 }
-

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -206,10 +206,7 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
     struct cluster_config *config;
 
     if (!h || !(id = malloc (sizeof (flux_jobid_t)))) {
-        return flux_jobtap_reject_job (p,
-                                       args,
-                                       "error processing delegate: %s",
-                                       strerror (errno));
+        return flux_jobtap_reject_job (p, args, "error processing delegate: %s", strerror (errno));
     }
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
@@ -477,10 +474,12 @@ int flux_plugin_init (flux_plugin_t *p)
     struct cluster_config *config;
     flux_t *h = flux_jobtap_get_flux (p);
 
-    if (!h
-        || flux_plugin_register (p, "delegate", tab) < 0
-        || !(config = selection_init(h))
-        || flux_plugin_aux_set (p, "flux::delegate::selection_config", config, (flux_free_f)selection_destroy) < 0) {
+    if (!h || flux_plugin_register (p, "delegate", tab) < 0 || !(config = selection_init (h))
+        || flux_plugin_aux_set (p,
+                                "flux::delegate::selection_config",
+                                config,
+                                (flux_free_f)selection_destroy)
+               < 0) {
         return -1;
     }
     return 0;

--- a/t/scripts/run_timeout.py
+++ b/t/scripts/run_timeout.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """run command with a timeout, timeout as a float is first argument, rest are command"""
+
 import argparse
 import os
 import signal


### PR DESCRIPTION
Problem: the repository lacks automated code style checking and
formatting enforcement.

Add .pre-commit-config.yaml from flux-sched to enable pre-commit hooks
for Python (ruff) and C/C++ (clang-format) code formatting. This ensures
consistent code style across the project.

Once this is merged, you can set up the formatter to run automatically before committing with `pre-commit install`.