### PR TITLE
Source cluster could kill jobs in a Target cluster

### DIFF
--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -144,8 +144,7 @@ static void submit_callback (flux_future_t *f, void *arg)
     }
     if (!(orig_id = flux_future_aux_get (f, "flux::jobid"))) {
         flux_log_error (h, "in submit callback: couldn't get jobid");
-        flux_future_destroy (f);
-        return;
+        goto error;
     }
     *id_for_event = *orig_id;
     *id_for_wait = *orig_id;
@@ -178,6 +177,13 @@ static void submit_callback (flux_future_t *f, void *arg)
         flux_log_error (h, "unable to save delegated jobId");
     }
     flux_future_destroy (f);
+    return;
+error:
+    free (id_for_event);
+    free (id_for_wait);
+    free (idcpy);
+    flux_future_destroy (f);
+    return;
 }
 
 /*

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -473,11 +473,42 @@ static int run_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args,
 
     return 0;
 }
+static int destroy_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+    flux_jobid_t job_id, *delegated_job_id;
+    flux_future_t *cancel_future = NULL;
+    flux_t *delegated_handle = NULL;
+    if (!h)
+        return -1;
+
+    if (!(delegated_job_id =
+              flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "flux::delegate::delegate_id")))
+        return 0;
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN, "{s:I}", "id", &job_id) < 0) {
+        flux_log_error (h, "flux_plugin_arg_unpack for jobid");
+        return 0;
+    }
+    if (!(delegated_handle = flux_jobtap_job_aux_get (p, job_id, "flux::delegated_handle"))) {
+        flux_log_error (h, "job is delegated but its handle not found");
+        return -1;
+    }
+    if (!(cancel_future =
+              flux_job_cancel (delegated_handle, *delegated_job_id, "Cancelled by parent cluster"))
+        || flux_future_get (cancel_future, NULL) < 0) {
+        flux_log_error (h,
+                        "Unable to cancel job in child cluster %s",
+                        flux_future_error_string (cancel_future));
+        return 0;
+    }
+    return 0;
+}
 
 static const struct flux_plugin_handler tab[] = {
     {"job.dependency.delegate", depend_cb, NULL},
     {"job.state.sched", sched_cb, NULL},
     {"job.state.run", run_cb, NULL},
+    {"job.destroy", destroy_cb, NULL},
     {0},
 };
 

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -62,6 +62,22 @@ static void wait_callback (flux_future_t *f, void *arg)
     flux_future_destroy (f);
 }
 
+static void cancel_callback (flux_future_t *f, void *arg)
+{
+    flux_plugin_t *p = arg;
+    flux_t *h;
+    const char *errstr;
+    if (!(h = flux_jobtap_get_flux (p))) {
+        flux_future_destroy (f);
+        return;
+    }
+    if (!(errstr = flux_future_error_string (f))) {
+        flux_future_destroy (f);
+        return;
+    }
+    flux_log_error (h, "Target Instance job cancel failure, Error: %s", errstr);
+    flux_future_destroy (f);
+}
 /*
  * Callback firing when events are ready.
  */
@@ -115,9 +131,7 @@ static void submit_callback (flux_future_t *f, void *arg)
     flux_t *h, *delegated_h;
     flux_plugin_t *p = arg;
     flux_jobid_t delegated_id, *orig_id, *idcpy = NULL, *id_for_wait = NULL, *id_for_event = NULL;
-    ;
     flux_future_t *wait_future = NULL, *event_future = NULL;
-
     const char *errstr;
     if (!(h = flux_jobtap_get_flux (p))) {
         flux_future_destroy (f);
@@ -273,7 +287,8 @@ static int depend_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *ar
     if (!(encoded_jobspec = remove_dependency_and_encode (jobspec))
         || !(jobid_future = flux_job_submit (delegated, encoded_jobspec, 16, FLUX_JOB_WAITABLE))
         || flux_future_then (jobid_future, -1, submit_callback, p) < 0
-        || flux_future_aux_set (jobid_future, "flux::jobid", id, NULL) < 0) {
+        || flux_future_aux_set (jobid_future, "flux::jobid", id, NULL) < 0
+        || flux_jobtap_job_subscribe (p, *id) < 0) {
         flux_log_error (h,
                         "%s: could not delegate job to specified Flux "
                         "instance",
@@ -473,32 +488,53 @@ static int run_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args,
 
     return 0;
 }
-static int destroy_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
+static int exception_cb (flux_plugin_t *p, const char *topic, flux_plugin_arg_t *args, void *arg)
 {
     flux_t *h = flux_jobtap_get_flux (p);
     flux_jobid_t job_id, *delegated_job_id;
+    int severity = 0;
+    json_t *context;
+    const char *name;
     flux_future_t *cancel_future = NULL;
     flux_t *delegated_handle = NULL;
     if (!h)
         return -1;
-
     if (!(delegated_job_id =
               flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "flux::delegate::delegate_id")))
         return 0;
-    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN, "{s:I}", "id", &job_id) < 0) {
-        flux_log_error (h, "flux_plugin_arg_unpack for jobid");
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:{s:s s:o}}",
+                                "id",
+                                &job_id,
+                                "entry",
+                                "name",
+                                &name,
+                                "context",
+                                &context)
+        < 0) {
+        flux_log_error (h, "flux_plugin_arg_unpack");
         return 0;
     }
+
+    if (!strcmp (name, "exception")) {
+        if (json_unpack (context, "{s:i}", "severity", &severity) < 0) {
+            flux_log_error (h, "unpacking exception context");
+            return 0;
+        }
+    }
+    if (severity != 0)
+        return 0;
+
     if (!(delegated_handle = flux_jobtap_job_aux_get (p, job_id, "flux::delegated_handle"))) {
         flux_log_error (h, "job is delegated but its handle not found");
         return -1;
     }
     if (!(cancel_future =
               flux_job_cancel (delegated_handle, *delegated_job_id, "Cancelled by parent cluster"))
-        || flux_future_get (cancel_future, NULL) < 0) {
-        flux_log_error (h,
-                        "Unable to cancel job in child cluster %s",
-                        flux_future_error_string (cancel_future));
+        || flux_future_then (cancel_future, -1, cancel_callback, p) < 0) {
+        flux_log_error (h, "error cancel");
+        flux_future_destroy (cancel_future);
         return 0;
     }
     return 0;
@@ -508,7 +544,7 @@ static const struct flux_plugin_handler tab[] = {
     {"job.dependency.delegate", depend_cb, NULL},
     {"job.state.sched", sched_cb, NULL},
     {"job.state.run", run_cb, NULL},
-    {"job.destroy", destroy_cb, NULL},
+    {"job.event.exception", exception_cb, NULL},
     {0},
 };
 

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -141,6 +141,7 @@ static void submit_callback (flux_future_t *f, void *arg)
         || !(id_for_event = malloc (sizeof (*id_for_event)))
         || !(idcpy = malloc (sizeof (*idcpy)))) {
         flux_log_error (h, "Unable to create flux_ids");
+        goto error;
     }
     if (!(orig_id = flux_future_aux_get (f, "flux::jobid"))) {
         flux_log_error (h, "in submit callback: couldn't get jobid");
@@ -170,6 +171,7 @@ static void submit_callback (flux_future_t *f, void *arg)
         flux_future_destroy (wait_future);
         flux_future_destroy (event_future);
         flux_future_destroy (f);
+        free (idcpy);
         return;
     }
     *idcpy = delegated_id;

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -137,24 +137,20 @@ static void submit_callback (flux_future_t *f, void *arg)
         flux_future_destroy (f);
         return;
     }
-    if (!(id_for_wait = malloc (sizeof (*id_for_wait)))
-        || !(id_for_event = malloc (sizeof (*id_for_event)))
-        || !(idcpy = malloc (sizeof (*idcpy)))) {
-        flux_log_error (h, "Unable to create flux_ids");
-        goto error;
-    }
     if (!(orig_id = flux_future_aux_get (f, "flux::jobid"))) {
         flux_log_error (h, "in submit callback: couldn't get jobid");
-        goto error;
+        flux_future_destroy (f);
+        return;
     }
-    *id_for_event = *orig_id;
-    *id_for_wait = *orig_id;
     if (!(delegated_h = flux_future_get_flux (f)) || flux_job_submit_get_id (f, &delegated_id) < 0
         || !(wait_future = flux_job_wait (delegated_h, delegated_id))
-        || flux_future_aux_set (wait_future, "flux::jobid", id_for_wait, free) < 0
-        || flux_future_then (wait_future, -1, wait_callback, p) < 0
-        || !(event_future = flux_job_event_watch (delegated_h, delegated_id, "eventlog", 0))
-        || flux_future_aux_set (event_future, "flux::jobid", id_for_event, free) < 0
+        || !(id_for_wait = malloc (sizeof (*id_for_wait)))
+        || flux_future_then (wait_future, -1, wait_callback, p) < 0) {
+        goto error;
+    }
+
+    if (!(event_future = flux_job_event_watch (delegated_h, delegated_id, "eventlog", 0))
+        || !(id_for_event = malloc (sizeof (*id_for_event))) || !(idcpy = malloc (sizeof (*idcpy)))
         || flux_future_aux_set (event_future, "flux::handle", h, NULL) < 0
         || flux_future_then (event_future, -1, event_callback, p) < 0
         || flux_jobtap_event_post_pack (p,
@@ -168,19 +164,29 @@ static void submit_callback (flux_future_t *f, void *arg)
             errstr = "";
         }
         flux_jobtap_raise_exception (p, *orig_id, "DelegationFailure", 0, errstr);
-        flux_future_destroy (wait_future);
-        flux_future_destroy (event_future);
-        flux_future_destroy (f);
-        free (idcpy);
-        return;
+        goto error;
     }
+    *id_for_wait = *orig_id;
+    *id_for_event = *orig_id;
     *idcpy = delegated_id;
+    if (flux_future_aux_set (wait_future, "flux::jobid", id_for_wait, free) < 0) {
+        goto error;
+    }
+    id_for_wait = NULL;
+    if (flux_future_aux_set (event_future, "flux::jobid", id_for_event, free) < 0)
+        goto error;
+    id_for_event = NULL;
     if (flux_jobtap_job_aux_set (p, *orig_id, "flux::delegate::delegate_id", idcpy, free) < 0) {
         flux_log_error (h, "unable to save delegated jobId");
+        goto error;
     }
+    idcpy=NULL;
     flux_future_destroy (f);
     return;
 error:
+    flux_log_error (h, "%s: submission to specified Flux instance failed", idf58 (*orig_id));
+    flux_future_destroy (wait_future);
+    flux_future_destroy (event_future);
     free (id_for_event);
     free (id_for_wait);
     free (idcpy);

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -180,7 +180,7 @@ static void submit_callback (flux_future_t *f, void *arg)
         flux_log_error (h, "unable to save delegated jobId");
         goto error;
     }
-    idcpy=NULL;
+    idcpy = NULL;
     flux_future_destroy (f);
     return;
 error:

--- a/src/job-manager/plugins/delegate.c
+++ b/src/job-manager/plugins/delegate.c
@@ -114,24 +114,33 @@ static void submit_callback (flux_future_t *f, void *arg)
 {
     flux_t *h, *delegated_h;
     flux_plugin_t *p = arg;
-    flux_jobid_t delegated_id, *orig_id;
+    flux_jobid_t delegated_id, *orig_id, *idcpy = NULL, *id_for_wait = NULL, *id_for_event = NULL;
+    ;
     flux_future_t *wait_future = NULL, *event_future = NULL;
-    const char *errstr;
 
+    const char *errstr;
     if (!(h = flux_jobtap_get_flux (p))) {
         flux_future_destroy (f);
         return;
-    } else if (!(orig_id = flux_future_aux_get (f, "flux::jobid"))) {
+    }
+    if (!(id_for_wait = malloc (sizeof (*id_for_wait)))
+        || !(id_for_event = malloc (sizeof (*id_for_event)))
+        || !(idcpy = malloc (sizeof (*idcpy)))) {
+        flux_log_error (h, "Unable to create flux_ids");
+    }
+    if (!(orig_id = flux_future_aux_get (f, "flux::jobid"))) {
         flux_log_error (h, "in submit callback: couldn't get jobid");
         flux_future_destroy (f);
         return;
     }
+    *id_for_event = *orig_id;
+    *id_for_wait = *orig_id;
     if (!(delegated_h = flux_future_get_flux (f)) || flux_job_submit_get_id (f, &delegated_id) < 0
         || !(wait_future = flux_job_wait (delegated_h, delegated_id))
-        || flux_future_aux_set (wait_future, "flux::jobid", orig_id, NULL) < 0
+        || flux_future_aux_set (wait_future, "flux::jobid", id_for_wait, free) < 0
         || flux_future_then (wait_future, -1, wait_callback, p) < 0
         || !(event_future = flux_job_event_watch (delegated_h, delegated_id, "eventlog", 0))
-        || flux_future_aux_set (event_future, "flux::jobid", orig_id, NULL) < 0
+        || flux_future_aux_set (event_future, "flux::jobid", id_for_event, free) < 0
         || flux_future_aux_set (event_future, "flux::handle", h, NULL) < 0
         || flux_future_then (event_future, -1, event_callback, p) < 0
         || flux_jobtap_event_post_pack (p,
@@ -144,12 +153,15 @@ static void submit_callback (flux_future_t *f, void *arg)
         if (!(errstr = flux_future_error_string (f))) {
             errstr = "";
         }
-        flux_log_error (h, "%s: submission to specified Flux instance failed", idf58 (*orig_id));
         flux_jobtap_raise_exception (p, *orig_id, "DelegationFailure", 0, errstr);
         flux_future_destroy (wait_future);
         flux_future_destroy (event_future);
         flux_future_destroy (f);
         return;
+    }
+    *idcpy = delegated_id;
+    if (flux_jobtap_job_aux_set (p, *orig_id, "flux::delegate::delegate_id", idcpy, free) < 0) {
+        flux_log_error (h, "unable to save delegated jobId");
     }
     flux_future_destroy (f);
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -20,7 +20,8 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 TESTSCRIPTS = \
 	t0000-sharness.t \
 	t1000-delegate-load.t \
-	t1001-delegate-assign.t
+	t1001-delegate-assign.t \
+	t1002-delegate-cancel.t
 
 # dist_check_SCRIPTS are built and installed for 'make distcheck'
 dist_check_SCRIPTS = \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -16,7 +16,6 @@ TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/config/tap-driver.sh
 
-# Test scripts
 TESTSCRIPTS = \
 	t0000-sharness.t \
 	t1000-delegate-load.t \

--- a/t/t1002-delegate-cancel.t
+++ b/t/t1002-delegate-cancel.t
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+test_description='Test delegate plugin cancellation propagation (source <-> target)'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 3
+
+# Check if we're in test environment with flux available
+if ! command -v flux >/dev/null 2>&1; then
+	skip_all='flux command not found, skipping tests'
+	test_done
+fi
+
+# Helper: extract the delegated jobid recorded in the source job's
+# delegate::submit eventlog entry.
+extract_delegated_id() {
+	flux job eventlog "$1" |
+		sed -nE "/delegate::submit/ s/.*jobid[\"=:[:space:]]+(\"?)([^\",}[:space:]]+).*/\2/p" |
+		head -n 1
+}
+
+test_expect_success 'start one target sub-instance' '
+	target_0=$(flux batch -n1 -t120s --wrap sleep inf) &&
+	flux job wait-event ${target_0} start 
+'
+
+test_expect_success 'configure delegate plugin with one target URI' '
+	uri_0=$(flux uri --local ${target_0}) &&
+	printf "delegate = [ \"%s\" ]\n" "${uri_0}"  |
+		flux config load && flux config get | jq -e .
+'
+
+test_expect_success 'plugin can be loaded' '
+	flux jobtap load "${SHARNESS_TEST_SRCDIR}"/../src/job-manager/plugins/.libs/delegate.so &&
+	flux jobtap list | grep delegate.so
+'
+
+#
+# Test 1: cancelling the job in the SOURCE instance must propagate the
+# cancellation down to the delegated job in the TARGET instance.
+#
+test_expect_success 'cancel from source propagates to target' '
+	jobid=$(flux submit --dependency=delegate:random sleep inf) &&
+	flux job wait-event --timeout=60 ${jobid} delegate::submit &&
+	delegated_id=$(extract_delegated_id ${jobid}) &&
+	test -n "${delegated_id}" &&
+	# the delegated job is actually running in the target
+	flux proxy ${uri_0} flux job wait-event --timeout=60 ${delegated_id} start &&
+	# cancel from the source side
+	flux cancel ${jobid} &&
+	flux job wait-event --timeout=60 ${jobid} clean &&
+	flux proxy ${uri_0} flux job wait-event --timeout=60 ${delegated_id} clean &&
+	flux proxy ${uri_0} flux job eventlog ${delegated_id} |
+		grep -E "exception" | grep -q "cancel"
+'
+
+test_expect_success 'no jobs left running in target after source cancel' '
+	test $(flux proxy ${uri_0} flux jobs --no-header --filter=running |
+		wc -l) -eq 0
+'
+
+#
+# Test 2: cancelling the delegated job directly in the TARGET instance must
+# propagate back up as a DelegationFailure exception on the SOURCE job.
+#
+test_expect_success 'cancel from target raises exception on source' '
+	jobid=$(flux submit --dependency=delegate:random sleep inf) &&
+	flux job wait-event --timeout=60 ${jobid} delegate::submit &&
+	delegated_id=$(extract_delegated_id ${jobid}) &&
+	test -n "${delegated_id}" &&
+	flux proxy ${uri_0} flux job wait-event --timeout=60 ${delegated_id} start &&
+	# cancel the delegated job *inside* the target instance
+	flux proxy ${uri_0} flux cancel ${delegated_id} &&
+	# wait_callback should raise DelegationFailure on the source job
+	flux job wait-event --timeout=60 \
+		--match-context=type=DelegationFailure ${jobid} exception &&
+	flux job eventlog ${jobid} | grep -q "DelegationFailure"
+'
+
+test_expect_success 'source job is inactive after target-side cancel' '
+	flux job wait-event --timeout=60 ${jobid} clean
+'
+
+test_expect_success 'unload delegate plugin' '
+	flux jobtap remove delegate.so
+'
+
+test_expect_success 'cancel subinstances' '
+	flux cancel --all
+'
+
+test_done
+

--- a/t/t1002-delegate-cancel.t
+++ b/t/t1002-delegate-cancel.t
@@ -6,12 +6,6 @@ test_description='Test delegate plugin cancellation propagation (source <-> targ
 
 test_under_flux 3
 
-# Check if we're in test environment with flux available
-if ! command -v flux >/dev/null 2>&1; then
-	skip_all='flux command not found, skipping tests'
-	test_done
-fi
-
 # Helper: extract the delegated jobid recorded in the source job's
 # delegate::submit eventlog entry.
 extract_delegated_id() {


### PR DESCRIPTION
## Summary

Fixes #25, we can now kill jobs from the _source_ cluster.

## Changes

- Enabled cancelling jobs originating from the **source** cluster.
- Fixed a memory issue in `wait_cb` where the `id` value could be NULL.

### Background on the memory fix
The job id value was created and stored in `depend_cb`, and its lifecycle was tied to the job's lifecycle in the _source_ cluster. This caused a problem in the following scenario:

- A job is cancelled in the _source_ cluster.
- The cancellation propagates to the _target_ cluster.
- The job transitions to INACTIVE in the _source_ cluster, which removes its `id` value.
The jobtap plugin still receives a callback from the _target_ cluster, which expects the `id` to exist, resulting in a NULL value.
Fix: Each future in `submit_callback` now gets its own `id` value, so it no longer depends on the _source_ cluster job's lifecycle.

## Tests
 Added test cases covering:

- Killing a job from the _source_ cluster and verifying it propagates to the _target_ cluster.
- Killing a job in the _target_ cluster and verifying the cancellation propagates back to the _source_ cluster.